### PR TITLE
Use v0.1.3 of arduino_ci

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,7 +1,7 @@
 ---
 name: Hadolint
 
-on: [push]
+on: [pull_request]
 
 jobs:
   hadolint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Now uses `arduino_ci` [version `1.3.0`](https://github.com/Arduino-CI/arduino_ci/blob/master/CHANGELOG.md#130---2021-01-13)
 
 ### Deprecated
 
 ### Removed
+- The use of `SKIP_LIBRARY_PROPERTIES`
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to the Arduino CI GitHub Action
+
+`ArduinoCI/action` uses a very standard GitHub workflow.
+
+1. Fork the repository on github
+2. Make your desired changes on top of the latest `master` branch, document them in [CHANGELOG.md](CHANGELOG.md)
+3. Push to your personal fork
+4. Open a pull request
+    * If you are submitting code, use `master` as the base branch
+    * If you are submitting broken unit tests (illustrating a bug that should be fixed), use `tdd` as the base branch.
+
+
+## Maintaining the Action
+
+* Merge pull request with new features
+* `git stash save` (at least before the push step, but easiest here).
+* `git pull --rebase`
+* Update the sections of `CHANGELOG.md`
+* `git add README.md CHANGELOG.md
+* `git commit -m "vVERSION bump"`
+* `git tag -a vVERSION -m "Released version VERSION"`
+* `gem build arduino_ci.gemspec`
+* `git stash pop`
+* `git push upstream`
+* `git push upstream master:latest`
+* `git push upstream master:stable-1.x`
+* `git push upstream --tags`
+* `git checkout master`
+* `git stash pop`

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ARG BUILD_VERSION
 ARG ARDUINO_CI_ACTION_REPO="https://github.com/ArduinoCI/action"
 ARG ARDUINO_CI_MAINTAINER="Arduino Continuous Integration <arduino.continuous.integration@gmail.com>"
 ARG ARDUINO_CI_GITREPO="https://github.com/ArduinoCI/arduino_ci.git"
-ARG ARDUINO_CI_GITREF="tag: 'v1.2.0'"
+ARG ARDUINO_CI_GITREF="tag: 'v1.3.0'"
 #ARG ARDUINO_CI_GITREPO="https://github.com/ianfixes/arduino_ci.git"
-#ARG ARDUINO_CI_GITREF="branch: '2020-12-28_wrapup'"
+#ARG ARDUINO_CI_GITREF="branch: '2021-01-07_beta'"
 
 LABEL com.github.actions.name="Arduino CI" \
       com.github.actions.description="Unit testing and example compilation for Arduino libraries" \
@@ -59,7 +59,7 @@ RUN true \
   && mkdir -p /action/bundle \
   && echo "source 'https://rubygems.org'" > $BUNDLE_GEMFILE \
 #  && echo "gem 'arduino_ci', git: '$ARDUINO_CI_GITREPO', $ARDUINO_CI_GITREF" >> $BUNDLE_GEMFILE \
-  && echo "gem 'arduino_ci', '=1.2.0'" >> $BUNDLE_GEMFILE \
+  && echo "gem 'arduino_ci', '=1.3.0'" >> $BUNDLE_GEMFILE \
   && cat $BUNDLE_GEMFILE \
   && bundle install --gemfile /action/Gemfile --path /action/bundle \
   && find /action |grep arduino_ci.rb


### PR DESCRIPTION
### Changed
- Now uses `arduino_ci` [version `1.3.0`](https://github.com/Arduino-CI/arduino_ci/blob/master/CHANGELOG.md#130---2021-01-13)

### Removed
- The use of `SKIP_LIBRARY_PROPERTIES`; use `arduino-lint` for all `library.properties` validation.


## Issues Fixed

* Fixes #15 