### PR TITLE
Fix pip and v0.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,11 @@ RUN true \
       g++ \
       time \
       python \
-      python-pip \
       python3 \
       python3-pip \
+  && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py \
+  && python get-pip.py \
+  && rm -rf get-pip.py \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && pip install pyserial \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_VERSION
 ARG ARDUINO_CI_ACTION_REPO="https://github.com/ArduinoCI/action"
 ARG ARDUINO_CI_MAINTAINER="Arduino Continuous Integration <arduino.continuous.integration@gmail.com>"
 ARG ARDUINO_CI_GITREPO="https://github.com/ArduinoCI/arduino_ci.git"
-ARG ARDUINO_CI_GITREF="tag: 'v1.3.0'"
+ARG ARDUINO_CI_GITREF="tag: 'v1.4.0'"
 #ARG ARDUINO_CI_GITREPO="https://github.com/ianfixes/arduino_ci.git"
 #ARG ARDUINO_CI_GITREF="branch: '2021-01-07_beta'"
 
@@ -61,7 +61,7 @@ RUN true \
   && mkdir -p /action/bundle \
   && echo "source 'https://rubygems.org'" > $BUNDLE_GEMFILE \
 #  && echo "gem 'arduino_ci', git: '$ARDUINO_CI_GITREPO', $ARDUINO_CI_GITREF" >> $BUNDLE_GEMFILE \
-  && echo "gem 'arduino_ci', '=1.3.0'" >> $BUNDLE_GEMFILE \
+  && echo "gem 'arduino_ci', '=1.4.0'" >> $BUNDLE_GEMFILE \
   && cat $BUNDLE_GEMFILE \
   && bundle install --gemfile /action/Gemfile --path /action/bundle \
   && find /action |grep arduino_ci.rb


### PR DESCRIPTION
* fix: "'python-pip' has no installation candidate" from @Di-Strix repo
* bump to arduino_ci v. 0.1.4